### PR TITLE
preview_demos: return valid URL on windows

### DIFF
--- a/src/preview.jl
+++ b/src/preview.jl
@@ -112,7 +112,11 @@ function preview_demos(demo_path::String;
 
         demos_cb()
 
-        return abspath(build, "index.html")
+        return if Sys.iswindows()
+            "file:///" * replace(abspath(build, "index.html"), "\\" => "/")
+        else
+            abspath(build, "index.html")
+        end
     end
 end
 


### PR DESCRIPTION
I do find it convient to be able to be able to just copy from the terminal to the browser.
However, this doesn't work with a windows path.