### PR TITLE
Remove the frontmatter altogether

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DemoCards"
 uuid = "311a05b2-6137-4a5a-b473-18580a3d38b5"
 authors = ["Johnny Chen <johnnychen94@hotmail.com>"]
-version = "0.4.9"
+version = "0.4.10"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
Currently Pluto.jl keeps the frontmatter text, even if the uuid has been removed from the chain of uuids. This results in a concat of all config in the last paragraph. This pr removes the frontmatter from the code altogether.