### PR TITLE
Use pluto frontmatter instead of regex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DemoCards"
 uuid = "311a05b2-6137-4a5a-b473-18580a3d38b5"
 authors = ["Johnny Chen <johnnychen94@hotmail.com>"]
-version = "0.4.10"
+version = "0.4.11"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -19,7 +19,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 Documenter = "0.22, 0.23, 0.24, 0.25, 0.26, 0.27"
-Pluto = "^0.19"
+Pluto = "^0.19.13"
 PlutoStaticHTML = "^6"
 FileIO = "1"
 HTTP = "0.6, 0.7, 0.8, 0.9, 1"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,7 +19,7 @@ end
 ### common utils for DemoPage and DemoSection
 
 function validate_order(order::AbstractArray, x::Union{DemoPage, DemoSection})
-    default_order = get_default_order(x)
+    default_order = gnb_pathet_default_order(x)
     if intersect(order, default_order) == union(order, default_order)
         return true
     else
@@ -143,28 +143,6 @@ function get_regex(::Val{:Markdown}, regex_type)
     end
 end
 
-
-function get_regex(::Val{:Pluto}, regex_type)
-    if regex_type == :image
-        # Example: ![title](path)
-        return r"^\s*!\[(?<title>[^\]]*)\]\((?<path>[^\s]*)\)"
-    elseif regex_type == :title
-        # Example: # [title](@id id)
-        regex_title = r"md[\"]{1,3}.*\n#\s(\S.*)\n"
-        # Example: # title
-        regex_simple_title = r"md[\"]{1,3}.*\n#\s(\S.*)\n"
-
-        # Note: return the complete one first
-        return (regex_title, regex_simple_title)
-    elseif regex_type == :content
-        # lines that are not title, image, link, list
-        # FIXME: list is also captured by this regex
-        return r"^\s*(?<content>[^#\-*!].*)"
-    else
-        error("Unrecognized regex type: $(regex_type)")
-    end
-end
-
 function get_regex(::Val{:Julia}, regex_type)
     if regex_type == :image
         # Example: #md ![title](path)
@@ -213,8 +191,8 @@ Currently supported items are: `title`, `id`, `cover`, `description`.
 function parse(T::Val, card::AbstractDemoCard)
     # TODO: generalize
     if T === Val(:Pluto)
-      header, frontmatter, body = split_pluto_frontmatter(readlines(card.path))
-      config = parse(T, body) # should ideally not pickup
+      frontmatter = []
+      config = Pluto.frontmatter(card.path)
     else
       header, frontmatter, body = split_frontmatter(readlines(card.path))
       config = parse(T, body)
@@ -367,28 +345,6 @@ function split_frontmatter(contents::AbstractArray{<:AbstractString})
     end
 
     return contents[1:offsets[1]-1], frontmatter, contents[offsets[2]+1:end]
-end
-
-
-# special case, generalize it with rest of functions later
-function split_pluto_frontmatter(contents)
-    first_cell_regex = r"#\s╔═╡\sCell\sorder:\n#\s?[╠╟][─═]\s?([0-9a-f\-]{36})"
-    content = join(contents, "\n")
-    first_cell_id = match(first_cell_regex, content)[1]
-    m1 = r"#\s╔═╡\s"
-    m2 = Regex("$(first_cell_id)\n")
-    m3 = r"""md\"\"\"\n([\s\S]*?)\"\"\""""
-    first_cell_regex = m1 * m2 * m3
-    frontmatter = match(first_cell_regex, content)[1]
-    frontmatter = split(frontmatter, "\n") |> Vector{String}
-    content_id_repr = r"#\s?[╠╟][─═]\s?" * Regex("$(first_cell_id)")
-
-    offset = map(contents) do line
-        m = match(content_id_repr, line)
-        m isa RegexMatch
-    end |> findlast
-
-    return String[], frontmatter, vcat(contents[1:offset-1], contents[offset+1:end])
 end
 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,7 +19,7 @@ end
 ### common utils for DemoPage and DemoSection
 
 function validate_order(order::AbstractArray, x::Union{DemoPage, DemoSection})
-    default_order = gnb_pathet_default_order(x)
+    default_order = get_default_order(x)
     if intersect(order, default_order) == union(order, default_order)
         return true
     else


### PR DESCRIPTION
Pluto allows easy insertion and extraction of frontmatter, we should use that instead of using regex hacks. This commit makes the workflow much easier for Pluto.

Note: This pr makes the  #126  non-required.