### PR TITLE
Use Pluto's default frontmatter instead of using regex for config

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DemoCards"
 uuid = "311a05b2-6137-4a5a-b473-18580a3d38b5"
 authors = ["Johnny Chen <johnnychen94@hotmail.com>"]
-version = "0.4.10"
+version = "0.4.11"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -19,7 +19,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 Documenter = "0.22, 0.23, 0.24, 0.25, 0.26, 0.27"
-Pluto = "^0.19"
+Pluto = "^0.19.13"
 PlutoStaticHTML = "^6"
 FileIO = "1"
 HTTP = "0.6, 0.7, 0.8, 0.9, 1"


### PR DESCRIPTION
Pluto allows easy insertion and extraction of frontmatter, we should use that instead of using regex hacks. This commit makes the workflow much easier for Pluto.

Note: This pr makes the https://github.com/JuliaDocs/DemoCards.jl/pull/126 non-required.