### PR TITLE
propagate `src` to `cardtheme`

### DIFF
--- a/src/Themes/Themes.jl
+++ b/src/Themes/Themes.jl
@@ -40,6 +40,7 @@ include("bokehlist/bokehlist.jl")
 """
     cardtheme(theme = "grid";
               root = "<current-directory>",
+              src = "src",
               destination = "democards") -> templates, stylesheet_path
 
 For given theme, return the templates and path to stylesheet.
@@ -51,11 +52,12 @@ Available themes are:
 """
 function cardtheme(theme::AbstractString="grid";
                    root::AbstractString = Base.source_dir(),
+                   src::AbstractString = "src",
                    destination::String = "democards")
     templates, src_stylesheet_path = cardtheme(Val(Symbol(theme)))
 
     # a copy is needed because Documenter only support relative path inside root
-    absolute_root = joinpath(root, "src", destination)
+    absolute_root = joinpath(root, src, destination)
     filename = "$(theme)theme.css"
     out_stylesheet_path = joinpath(absolute_root, filename)
     isdir(absolute_root) || mkpath(absolute_root)

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -130,7 +130,7 @@ function makedemos(source::String, templates::Union{Dict, Nothing} = nothing;
     end
 
     if !isnothing(page.theme)
-        page_templates, theme_assets = cardtheme(page.theme, root = root)
+        page_templates, theme_assets = cardtheme(page.theme; root = root, src = src)
         theme_assets = something(page.stylesheet, theme_assets)
 
         if templates != page_templates && templates != nothing

--- a/src/preview.jl
+++ b/src/preview.jl
@@ -70,7 +70,7 @@ function preview_demos(demo_path::String;
         if isnothing(theme)
             card_templates = nothing
         else
-            card_templates, card_theme = cardtheme(theme; root = build_dir)
+            card_templates, card_theme = cardtheme(theme; root = build_dir, src = src)
             push!(assets, something(page.stylesheet, card_theme))
         end
 


### PR DESCRIPTION
`cardtheme` should not try copy to a hardcoded "src" path, and should instead copy to the `src` path given to `makedemos`.

CI errors unrelated.
Needed for https://github.com/JuliaPlots/PlotDocs.jl/pull/328.