### PR TITLE
allow empty section title

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -273,8 +273,12 @@ function generate(secs::AbstractVector{DemoSection}, templates; level=1, propert
 end
 
 function generate(sec::DemoSection, templates; level=1, properties=Dict{String, Any}())
-    header = repeat("#", level) * " " * sec.title * "\n"
-    footer = "\n"
+    header = if length(sec.title) > 0
+        repeat("#", level) * " " * sec.title
+    else
+        ""
+    end * '\n'
+    footer = '\n'
     properties = merge(properties, sec.properties) # sec.properties has higher priority
 
     # either cards or subsections are empty


### PR DESCRIPTION
Fix https://github.com/JuliaDocs/DemoCards.jl/issues/132.

Compare the side bar of:
https://docs.juliaplots.org/stable/gallery/gr (with section title)
versus
https://docs.juliaplots.org/dev/gallery/gr (without section title)
