### PR TITLE
revert broken PR

### DIFF
--- a/src/preview.jl
+++ b/src/preview.jl
@@ -112,11 +112,7 @@ function preview_demos(demo_path::String;
 
         demos_cb()
 
-        return if Sys.iswindows()
-            "file:///" * replace(abspath(build, "index.html"), "\\" => "/")
-        else
-            abspath(build, "index.html")
-        end
+        return abspath(build, "index.html")
     end
 end
 


### PR DESCRIPTION
Looks like https://github.com/JuliaDocs/DemoCards.jl/pull/122 broke windows ci.

Oddly, no `ci` checks were run on this `PR` (https://github.com/JuliaDocs/DemoCards.jl/pull/122/checks).

Revert until a better fix is found.

cc @BeastyBlacksmith 